### PR TITLE
Include Pgeof header into the source dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft include


### PR DESCRIPTION
this PR introduce a small fix to previous enhancements made to the build system (see #4).   Previously `pgeof.hpp` header was not included into the source distribution so `python -m build .` would fail even if `pip install .` works . This PR make `pgeof` truly `PEP-517` compatible (as long as `Eigen` header are available on the build machine)