### PR TITLE
pin nanobind version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core >=0.4.3", "nanobind >= 1.9.2"]
+requires = ["scikit-build-core >=0.4.3", "nanobind == 1.9.2"]
 build-backend = "scikit_build_core.build"
 
 [project]


### PR DESCRIPTION
Pin nanobind version, fix #14

nanobind 2.0.0 is out with breaking changes (nb::any is no longer part of the API for example). For now we pin nanobind to 1.9.2 to avoid build failures.